### PR TITLE
Move I2C#6 pins configuration to Device Tree

### DIFF
--- a/arch/x86/cpu/tangier/pinmux.c
+++ b/arch/x86/cpu/tangier/pinmux.c
@@ -89,7 +89,7 @@ mrfld_setup_families(void *base_addr, struct mrfld_family *families, unsigned in
 	}
 }
 
-int mrfld_pinconfig_protected(unsigned int pin, u32 mask, u32 bits)
+static int mrfld_pinconfig_protected(unsigned int pin, u32 mask, u32 bits)
 {
 	struct mrfld_pinctrl *pinctrl;
 	struct udevice *dev;

--- a/arch/x86/dts/edison.dts
+++ b/arch/x86/dts/edison.dts
@@ -89,5 +89,22 @@
 	pinctrl {
 		compatible = "intel,pinctrl-tangier";
 		reg = <0xff0c0000 0x8000>;
+
+		/*
+		 * Initial configuration came from the firmware.
+		 * Which quite likely has been used in the phones, where I2C #8,
+		 * that is not part of Atom peripheral, is in use.
+		 * Thus we need to override the leftover.
+		 */
+		i2c6_scl@0 {
+			pad-offset = <111>;
+			mode-func = <1>;
+			protected;
+		};
+		i2c6_sda@0 {
+			pad-offset = <112>;
+			mode-func = <1>;
+			protected;
+		};
 	};
 };

--- a/board/intel/edison/edison.c
+++ b/board/intel/edison/edison.c
@@ -20,14 +20,6 @@
 /* List of Intel Tangier LSSs */
 #define PMU_LSS_TANGIER_SDIO0_01	1
 
-/* List of Intel Tangier pins */
-#define MRFLD_I2C6_SCL	111
-#define MRFLD_I2C6_SDA	112
-
-/* These are taken from Linux kernel */
-#define MRFLD_PINMODE_MASK	0x07
-#define MRFLD_PIN_BITS	0x01
-
 void board_mmc_power_init(void)
 {
 	pmu_turn_power(PMU_LSS_TANGIER_SDIO0_01, true);
@@ -107,17 +99,6 @@ static void assign_hardware_id(void)
 #endif
 }
 
-int mrfld_i2c6_setup(void)
-{
-	u32 mask = MRFLD_PINMODE_MASK;
-	u32 bits = MRFLD_PIN_BITS;
-
-	mrfld_pinconfig_protected(MRFLD_I2C6_SCL, mask, bits);
-	mrfld_pinconfig_protected(MRFLD_I2C6_SDA, mask, bits);
-
-	return 0;
-}
-
 int board_late_init(void)
 {
 	if (!env_get("serial#"))
@@ -125,14 +106,6 @@ int board_late_init(void)
 
 	if (!env_get("hardware_id"))
 		assign_hardware_id();
-
-	/*
-	 * Initial configuration came from the firmware.
-	 * Which quite likely has been used in the phones, where I2C #8,
-	 * that is not part of Atom peripheral, is in use.
-	 * Thus we need to override the leftover.
-	 */
-	mrfld_i2c6_setup();
 
 	return 0;
 }


### PR DESCRIPTION
It's the first take to turn the driver into the full-blown pinctrl one.

- introduce an interface in pinmux.c to read the configuration from the DT
- move configuration of I2C#6 to edison.dts
- make mrfld_pinconfig_protected() static

@andy-shev 

It'd be nice if you could take a look and say if I'm on the right track here.